### PR TITLE
Type fix

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,8 +2,8 @@
 export interface UserAgent {
   // The original user agent string.
   readonly source: string,
-  readonly deviceType?: string,
-  readonly deviceVendor?: string,
+  readonly deviceType: string | null,
+  readonly deviceVendor: string | null,
   readonly os: string,
   readonly osVersion: number,
   readonly browser: string,

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -17,7 +17,7 @@ export function parse(phase: string): UserAgent {
   const isBot = phase ? regex.test(phase.toLowerCase()) : false
 
   const browser: string = result.browser.name
-  const deviceType: string = result.device.type
+  const deviceType: string = result.device.type || null
   const os: string = result.os.name
   const isMobile: boolean = deviceType === 'mobile'
   const isTablet: boolean = deviceType === 'tablet'
@@ -31,7 +31,7 @@ export function parse(phase: string): UserAgent {
     isTablet,
     isIos,
     source:         phase,
-    deviceVendor:   result.device.vendor,
+    deviceVendor:   result.device.vendor || null,
     osVersion:      parseInt(result.os.version, 10),
     browserVersion: parseFloat(result.browser.version),
     isIphone:       isMobile && isIos,


### PR DESCRIPTION
Hi there,
This PR will fix the `SerializableError` which return by next js, according to the official example.

This is the whole error message:
```
SerializableError: Error serializing `.ua.deviceType` returned from `getServerSideProps` in "/".
Reason: `undefined` cannot be serialized as JSON. Please use `null` or omit this value all together.
```