### PR TITLE
feat: expose parse function

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,49 @@ export function getServerSideProps(context) {
 }
 ```
 
+### Parse function
+
+The `parse` returns `UserAgent` instance.
+
+This works on server side and inside conditions without ESLint throwing errors
+
+```tsx
+import React from 'react'
+import dynamic from 'next/dynamic'
+import { parse } from 'next-useragent'
+
+const DesktopContent = dynamic(() => import('./desktop-content'))
+const MobileContent = dynamic(() => import('./mobile-content'))
+
+export default props => {
+  let ua;
+  if (props.uaString) {
+    ua = parse(props.uaString)
+  } else {
+    ua = parse(window.navigator.userAgent)
+  }
+
+  return (
+    <div>
+      <p>{ ua.source }</p>
+      { ua.isMobile ? (
+        <MobileContent />
+      ) : (
+        <DesktopContent />
+      ) }
+    </div>
+  )
+}
+
+export function getServerSideProps(context) {
+  return {
+    props: {
+      uaString: context.req.headers['user-agent']
+    }
+  }
+}
+```
+
 ### parsed objects
 
 The parsed objects looks like the following:

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,9 @@
 
 export { UserAgent } from './constants';
 export { useUserAgent } from './useUserAgent';
-export { WithUserAgentProps, WithUserAgentContext, withUserAgent } from './withUserAgent';
+export {
+  WithUserAgentProps,
+  WithUserAgentContext,
+  withUserAgent,
+} from './withUserAgent';
+export { parse } from './helpers';


### PR DESCRIPTION
Related issue: https://github.com/tokuda109/next-useragent/issues/365

This PR exports the function used inside `useUserAgent` to work around ESLint-ing issues when using a function named like a React hook.